### PR TITLE
Support multiple values for "sizeof" field tag

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -331,8 +331,8 @@ func (d *Decoder) decodeStruct(rt reflect.Type, rv reflect.Value) (err error) {
 		}
 
 		if fieldTag.SizeOf != nil {
+			size := sizeof(structField.Type, v)
 			for _, sizeOfField := range fieldTag.SizeOf {
-				size := sizeof(structField.Type, v)
 				if traceEnabled {
 					zlog.Debug("setting size of field",
 						zap.String("field_name", sizeOfField),

--- a/decoder.go
+++ b/decoder.go
@@ -330,15 +330,17 @@ func (d *Decoder) decodeStruct(rt reflect.Type, rv reflect.Value) (err error) {
 			return
 		}
 
-		if fieldTag.SizeOf != "" {
-			size := sizeof(structField.Type, v)
-			if traceEnabled {
-				zlog.Debug("setting size of field",
-					zap.String("field_name", fieldTag.SizeOf),
-					zap.Int("size", size),
-				)
+		if fieldTag.SizeOf != nil {
+			for _, sizeOfField := range fieldTag.SizeOf {
+				size := sizeof(structField.Type, v)
+				if traceEnabled {
+					zlog.Debug("setting size of field",
+						zap.String("field_name", sizeOfField),
+						zap.Int("size", size),
+					)
+				}
+				sizeOfMap[sizeOfField] = size
 			}
-			sizeOfMap[fieldTag.SizeOf] = size
 		}
 	}
 	return

--- a/encoder.go
+++ b/encoder.go
@@ -353,20 +353,22 @@ func (e *Encoder) encodeStruct(rt reflect.Type, rv reflect.Value) (err error) {
 
 		rv := rv.Field(i)
 
-		if fieldTag.SizeOf != "" {
-			if traceEnabled {
-				zlog.Debug("encode: struct field has sizeof tag",
-					zap.String("sizeof_field_name", fieldTag.SizeOf),
-					zap.String("struct_field_name", structField.Name),
-				)
+		if fieldTag.SizeOf != nil {
+			for _, sizeOfField := range fieldTag.SizeOf {
+				if traceEnabled {
+					zlog.Debug("encode: struct field has sizeof tag",
+						zap.String("sizeof_field_name", sizeOfField),
+						zap.String("struct_field_name", structField.Name),
+					)
+				}
+				sizeOfMap[sizeOfField] = sizeof(structField.Type, rv)
 			}
-			sizeOfMap[fieldTag.SizeOf] = sizeof(structField.Type, rv)
 		}
 
 		if !rv.CanInterface() {
 			if traceEnabled {
 				zlog.Debug("encode:  skipping field: unable to interface field, probably since field is not exported",
-					zap.String("sizeof_field_name", fieldTag.SizeOf),
+					zap.Strings("sizeof_field_name", fieldTag.SizeOf),
 					zap.String("struct_field_name", structField.Name),
 				)
 			}

--- a/encoder.go
+++ b/encoder.go
@@ -354,13 +354,13 @@ func (e *Encoder) encodeStruct(rt reflect.Type, rv reflect.Value) (err error) {
 		rv := rv.Field(i)
 
 		if fieldTag.SizeOf != nil {
+			if traceEnabled {
+				zlog.Debug("encode: struct field has sizeof tag",
+					zap.Strings("sizeof_field_names", fieldTag.SizeOf),
+					zap.String("struct_field_name", structField.Name),
+				)
+			}
 			for _, sizeOfField := range fieldTag.SizeOf {
-				if traceEnabled {
-					zlog.Debug("encode: struct field has sizeof tag",
-						zap.String("sizeof_field_name", sizeOfField),
-						zap.String("struct_field_name", structField.Name),
-					)
-				}
 				sizeOfMap[sizeOfField] = sizeof(structField.Type, rv)
 			}
 		}

--- a/parse.go
+++ b/parse.go
@@ -7,7 +7,7 @@ import (
 )
 
 type fieldTag struct {
-	SizeOf          string
+	SizeOf          []string
 	Skip            bool
 	Order           binary.ByteOrder
 	Optional        bool
@@ -21,8 +21,8 @@ func parseFieldTag(tag reflect.StructTag) *fieldTag {
 	tagStr := tag.Get("bin")
 	for _, s := range strings.Split(tagStr, " ") {
 		if strings.HasPrefix(s, "sizeof=") {
-			tmp := strings.SplitN(s, "=", 2)
-			t.SizeOf = tmp[1]
+			_, tmp, _ := strings.Cut(s, "=")
+			t.SizeOf = strings.Split(tmp, ",")
 		} else if s == "big" {
 			t.Order = binary.BigEndian
 		} else if s == "little" {

--- a/parse_test.go
+++ b/parse_test.go
@@ -34,7 +34,7 @@ func Test_parseFieldTag(t *testing.T) {
 			tag:  `bin:"sizeof=Tokens"`,
 			expectValue: &fieldTag{
 				Order:  binary.LittleEndian,
-				SizeOf: "Tokens",
+				SizeOf: []string{"Tokens"},
 			},
 		},
 		{
@@ -51,7 +51,15 @@ func Test_parseFieldTag(t *testing.T) {
 			expectValue: &fieldTag{
 				Order:    binary.LittleEndian,
 				Optional: true,
-				SizeOf:   "Nodes",
+				SizeOf:   []string{"Nodes"},
+			},
+		},
+		{
+			name: "multiple sizeof's",
+			tag:  `bin:"sizeof=Nodes,Tokens"`,
+			expectValue: &fieldTag{
+				Order:  binary.LittleEndian,
+				SizeOf: []string{"Nodes", "Tokens"},
 			},
 		},
 	}


### PR DESCRIPTION
With this its possible to specify multiple values for "sizeof" field tag like this: `bin:"sizeof=var1,var2"`

For example:
```go
type Example struct {
    ID int32
    Count uint32 `bin:"sizeof=Arr1,Arr2"`
    Arr1 []uint32
    Arr2 []uint32
}
```